### PR TITLE
Unset keybind change

### DIFF
--- a/ImGui.lua
+++ b/ImGui.lua
@@ -1009,7 +1009,7 @@ function ImGui:ContainerClass(Frame: Frame, Class, Window)
 			ValueText.Text = NewKey.Name
 			Config.Value = NewKey
 
-			if NewKey.Name == "World69" or NewKey.Name == "BackSpace" then
+			if NewKey.Name == "World69" or NewKey.Name == "Backspace" then
 				ValueText.Text = "Not set"
 				return
 			end

--- a/ImGui.lua
+++ b/ImGui.lua
@@ -1005,11 +1005,11 @@ function ImGui:ContainerClass(Frame: Frame, Class, Window)
 		end
 
 		function Config:SetValue(NewKey: Enum.KeyCode)
-			if not NewKey then return end
+			if not NewKey then newKey = Enum.KeyCode.World69 end -- World1-95 keycodes are unused by UserInputService
 			ValueText.Text = NewKey.Name
 			Config.Value = NewKey
 
-			if NewKey == Enum.KeyCode.Backspace then
+			if NewKey.Name == "World69" or NewKey.Name == "BackSpace" then
 				ValueText.Text = "Not set"
 				return
 			end


### PR DESCRIPTION
if the keybind is set to nil, which is only possible from the script, then it sets the bind to World69. This is better than having to set it to Enum.Keycode.Backspace.