### PR TITLE
Issue with Keybinds

### DIFF
--- a/ImGui.lua
+++ b/ImGui.lua
@@ -1031,6 +1031,7 @@ function ImGui:ContainerClass(Frame: Frame, Class, Window)
 
 		Config.Connection = UserInputService.InputBegan:Connect(function(Input, GameProcessed)
 			if not Config.IgnoreGameProcessed and GameProcessed then return end
+			if Config.Value == Enum.KeyCode.Backspace then return end
 
 			if Input.KeyCode == Config.Value then
 				return Callback(Input.KeyCode)


### PR DESCRIPTION
When a keybind is unset and the user presses backspace, it still triggers the callback. This is really annoying. This commit checks if the keybind is backspace and returns if true.